### PR TITLE
Changes for python3

### DIFF
--- a/optimus/__init__.py
+++ b/optimus/__init__.py
@@ -1,1 +1,1 @@
-from optimus import *
+from .optimus import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests==2.11.0
-
+requests>=2.11.1

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,21 @@
 from distutils.core import setup
 setup(
-  name = 'optimus-api',
-  packages = ['optimus'],
-  version = '0.3',
-  description = 'A Python API client for the Optimus image optimization service',
-  author = 'KeyCDN',
-  author_email = 'hello@keycdn.com',
-  url = 'https://github.com/keycdn/python-optimus-api',
-  download_url = 'https://github.com/keycdn/python-optimus-api/tarball/0.3',
-  keywords = ['image compression', 'image optimization', 'image optimizer', 'optimus'],
-  classifiers = [],
+  name='optimus-api',
+  packages=['optimus'],
+  version='0.4',
+  description='A Python API client for the Optimus image optimization service',
+  author='KeyCDN',
+  author_email='hello@keycdn.com',
+  url='https://github.com/keycdn/python-optimus-api',
+  download_url='https://github.com/keycdn/python-optimus-api/tarball/0.4',
+  keywords=[
+    'image compression',
+    'image optimization',
+    'image optimizer',
+    'optimus'
+  ],
+  classifiers=[
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3'
+  ],
 )


### PR DESCRIPTION
This fixes #1 
- adjusted module import for python3
- be more loose with the requests dependency
- set classifiers to exclude python versions prior to 2.7